### PR TITLE
Clear Console Feature

### DIFF
--- a/src/user_loop.rs
+++ b/src/user_loop.rs
@@ -1524,7 +1524,7 @@ fn print_user_loop_instructions(
     }
 }
 
-pub fn user_loop(credentials: &rv_api::AuthenticationResponse, terminal_io: &mut TerminalIO) {
+pub fn print_user_loop_banner(credentials: &rv_api::AuthenticationResponse, terminal_io: &mut TerminalIO) {
     execute!(
         terminal_io.writer,
         terminal::Clear(terminal::ClearType::All)
@@ -1532,6 +1532,11 @@ pub fn user_loop(credentials: &rv_api::AuthenticationResponse, terminal_io: &mut
     .unwrap();
     print_user_loop_instructions(credentials, terminal_io);
     printline(terminal_io, "");
+}
+
+pub fn user_loop(credentials: &rv_api::AuthenticationResponse, terminal_io: &mut TerminalIO) {
+    print_user_loop_banner(credentials, terminal_io);
+
     'main: loop {
         let user_info = rv_api::get_user_info(&credentials).unwrap();
         execute!(
@@ -1709,7 +1714,7 @@ pub fn user_loop(credentials: &rv_api::AuthenticationResponse, terminal_io: &mut
                             // Clear current terminal view
                             // Useful after registering, if you want to see the list of commands
                             // after logging in
-                            break user_loop(credentials, terminal_io);
+                            break print_user_loop_banner(credentials, terminal_io);
                         }
                         '0'..='9' => {
                             terminal_io.writer.execute(Print(c)).unwrap();

--- a/src/user_loop.rs
+++ b/src/user_loop.rs
@@ -1508,6 +1508,8 @@ fn print_user_loop_instructions(
         Print(" - change privacy\r\n"),
         PrintStyledContent("U".dark_green().bold()),
         Print(" - undo a recent purchase\r\n"),
+        PrintStyledContent("C".dark_green().bold()),
+        Print(" - clear terminal\r\n"),
         PrintStyledContent("<enter>".dark_green().bold()),
         Print(" - log out\r\n"),
     )
@@ -1706,6 +1708,12 @@ pub fn user_loop(credentials: &rv_api::AuthenticationResponse, terminal_io: &mut
                         '0'..='9' => {
                             terminal_io.writer.execute(Print(c)).unwrap();
                             command.push(c);
+                        }
+                        'c' => {
+                            // Clear current terminal view
+                            // Useful after registering, if you want to see the list of commands
+                            // after logging in
+                            break user_loop(credentials, terminal_io);
                         }
                         _ => (),
                     },

--- a/src/user_loop.rs
+++ b/src/user_loop.rs
@@ -1705,15 +1705,15 @@ pub fn user_loop(credentials: &rv_api::AuthenticationResponse, terminal_io: &mut
                             // Legacy behavior wanted by some old users, need not to show in the list of commands
                             break 'main; // Logout
                         }
-                        '0'..='9' => {
-                            terminal_io.writer.execute(Print(c)).unwrap();
-                            command.push(c);
-                        }
                         'c' => {
                             // Clear current terminal view
                             // Useful after registering, if you want to see the list of commands
                             // after logging in
                             break user_loop(credentials, terminal_io);
+                        }
+                        '0'..='9' => {
+                            terminal_io.writer.execute(Print(c)).unwrap();
+                            command.push(c);
                         }
                         _ => (),
                     },


### PR DESCRIPTION
This pull request includes a ~single~ two commit**s**, that adds command "C" to clear the current terminal view.
This is particularly useful after you have registered and logged in for the first time, as the terminal fills up.

I tested this locally using a local instance of `rv-frontend`.

I added the command to the list of commands:
![image](https://github.com/user-attachments/assets/7f29a485-9192-4697-aa11-5062d4d0f88d)

TLDR; How was this implemented? Simply by: `break user_loop(credentials, terminal_io);`